### PR TITLE
Restore proper attribution

### DIFF
--- a/Analysis-II/A2_cheatsheet.tex
+++ b/Analysis-II/A2_cheatsheet.tex
@@ -65,7 +65,7 @@
 
 % Metadata
 \title{Cheatsheet Analysis II}
-\author{Florian Affolter}
+\author{Julian Steinmann}
 \date{Wintersession 2023}
 
 % Math helper stuff


### PR DESCRIPTION
Overleaf automatically pushes the version with the "wrong" name every time. Pull this branch into main as soon as the exam is over and no more (frequent) changes from Overleaf are expected.